### PR TITLE
Support multi-chunk initv4 payload decoding

### DIFF
--- a/src/deobfuscator.py
+++ b/src/deobfuscator.py
@@ -236,6 +236,13 @@ class LuaDeobfuscator:
 
                 cleaned_meta = dict(payload_info.metadata)
                 cleaned_meta.pop(override_token, None)
+                cleaned_meta.pop("_chunks", None)
+                chunk_count = cleaned_meta.get("chunk_count")
+                if isinstance(chunk_count, int) and chunk_count > 0:
+                    metadata["handler_payload_chunks"] = chunk_count
+                chunk_bytes = cleaned_meta.get("chunk_decoded_bytes")
+                if isinstance(chunk_bytes, list):
+                    metadata["handler_chunk_decoded_bytes"] = list(chunk_bytes)
                 if cleaned_meta:
                     metadata["handler_payload_meta"] = cleaned_meta
 

--- a/src/passes/payload_decode.py
+++ b/src/passes/payload_decode.py
@@ -103,9 +103,22 @@ def run(ctx: "Context") -> Dict[str, Any]:
         raw_bytes = metadata.get("handler_vm_bytecode")
         if not lengths and isinstance(raw_bytes, (bytes, bytearray)):
             lengths.append(len(raw_bytes))
-        if lengths:
+        chunk_count = metadata.get("handler_payload_chunks")
+        if isinstance(chunk_count, int) and chunk_count > 0:
+            report.blob_count += chunk_count
+        elif lengths:
             report.blob_count += len(lengths)
+
+        if lengths:
             report.decoded_bytes += sum(lengths)
+        elif isinstance(metadata.get("handler_chunk_decoded_bytes"), list):
+            chunk_bytes = [
+                value
+                for value in metadata.get("handler_chunk_decoded_bytes", [])
+                if isinstance(value, int) and value >= 0
+            ]
+            if chunk_bytes:
+                report.decoded_bytes += sum(chunk_bytes)
 
         warnings = metadata.get("warnings")
         if isinstance(warnings, list):

--- a/src/versions/initv4.py
+++ b/src/versions/initv4.py
@@ -325,7 +325,7 @@ class InitV4Decoder:
     def locate_payload(self, source: str) -> List[str]:
         blobs: List[str] = []
         for match in _PAYLOAD_RE.finditer(source):
-            blobs.append(match.group(2))
+            blobs.append(match.group(0))
         return blobs
 
     # ------------------------------------------------------------------

--- a/src/versions/luraph_v14_4_1.py
+++ b/src/versions/luraph_v14_4_1.py
@@ -31,6 +31,9 @@ _SCRIPT_KEY_ASSIGN_RE = re.compile(
     re.IGNORECASE,
 )
 _HIGH_ENTROPY_RE = re.compile(rf"[{re.escape(_INITV4_ALPHABET)}]{{200,}}")
+_CHUNK_STRING_RE = re.compile(
+    rf'(["\'])([{re.escape(_INITV4_ALPHABET)}]{{40,}})\1'
+)
 _JSON_BLOCKS = (
     re.compile(r"\[\[(\s*\{.*?\})\]\]", re.DOTALL),
     re.compile(r'"(\{\s*\"constants\".*?\})"', re.DOTALL),
@@ -365,7 +368,23 @@ def _locate_json_block(text: str, *, start: int) -> Tuple[str, int, int, Dict[st
     return None
 
 
-def _locate_base64_blob(text: str, *, start: int) -> Tuple[str, int, int] | None:
+def _locate_payload_chunks(text: str, *, start: int) -> List[Tuple[str, int, int]]:
+    matches: List[Tuple[str, int, int]] = []
+    for match in _CHUNK_STRING_RE.finditer(text, pos=start):
+        chunk = match.group(2)
+        begin, end = match.span(2)
+        matches.append((chunk, begin, end))
+    if matches:
+        return matches
+
+    if start:
+        for match in _CHUNK_STRING_RE.finditer(text):
+            chunk = match.group(2)
+            begin, end = match.span(2)
+            matches.append((chunk, begin, end))
+    if matches:
+        return matches
+
     best: Tuple[str, int, int] | None = None
     for match in _HIGH_ENTROPY_RE.finditer(text, pos=start):
         blob = match.group(0)
@@ -373,15 +392,15 @@ def _locate_base64_blob(text: str, *, start: int) -> Tuple[str, int, int] | None
         if best is None or len(blob) > len(best[0]):
             best = (blob, span[0], span[1])
     if best:
-        return best
-    # Fallback to earlier blobs if none appeared after ``start``
+        return [best]
+
     if start:
         for match in _HIGH_ENTROPY_RE.finditer(text):
             blob = match.group(0)
             span = match.span(0)
             if best is None or len(blob) > len(best[0]):
                 best = (blob, span[0], span[1])
-    return best
+    return [best] if best else []
 
 
 _BASE_OPCODE_TABLE: Dict[int, OpSpec] = dict(LuraphV142JSON().opcode_table())
@@ -490,14 +509,24 @@ class LuraphV1441(VersionHandler):
             meta["format"] = "json"
             return PayloadInfo(blob, begin, end, data=data, metadata=meta)
 
-        base64_blob = _locate_base64_blob(text, start=start)
-        if base64_blob is None:
+        chunk_entries = _locate_payload_chunks(text, start=start)
+        if not chunk_entries:
             return None
 
-        blob, begin, end = base64_blob
+        chunks = [entry[0] for entry in chunk_entries]
+        begin = chunk_entries[0][1]
+        end = chunk_entries[-1][2]
         meta = dict(base_meta)
         meta.setdefault("format", "base64")
-        return PayloadInfo(blob, begin, end, metadata=meta)
+        if chunks:
+            meta["_chunks"] = list(chunks)
+            meta["chunk_count"] = len(chunks)
+            meta["chunks"] = [
+                {"offset": entry[1], "end": entry[2], "length": len(chunks[index])}
+                for index, entry in enumerate(chunk_entries)
+            ]
+        payload_text = chunks[0] if chunks else ""
+        return PayloadInfo(payload_text, begin, end, metadata=meta)
 
     def extract_bytecode(self, payload: PayloadInfo) -> bytes:
         metadata = payload.metadata or {}
@@ -528,11 +557,111 @@ class LuraphV1441(VersionHandler):
         if alphabet:
             metadata.setdefault("alphabet_length", len(alphabet))
 
-        raw, decode_meta = decode_blob_with_metadata(
-            payload.text,
-            script_key,
-            alphabet=alphabet,
-        )
+        chunk_texts_raw = metadata.pop("_chunks", None)
+        chunk_texts: List[str] | None = None
+        if isinstance(chunk_texts_raw, (list, tuple)):
+            filtered: List[str] = []
+            for entry in chunk_texts_raw:
+                if isinstance(entry, str) and entry:
+                    filtered.append(entry)
+            if filtered:
+                chunk_texts = filtered
+
+        if chunk_texts:
+            decoded_parts: List[bytes] = []
+            chunk_methods: List[str] = []
+            chunk_alphabets: List[str] = []
+            chunk_attempts: List[Dict[str, object]] = []
+            chunk_meta_details: List[Dict[str, object]] = []
+            chunk_decoded_bytes: List[int] = []
+            chunk_encoded_lengths = [len(chunk) for chunk in chunk_texts]
+
+            for index, chunk in enumerate(chunk_texts):
+                part, part_meta = decode_blob_with_metadata(
+                    chunk,
+                    script_key,
+                    alphabet=alphabet,
+                )
+                decoded_parts.append(part)
+                chunk_decoded_bytes.append(len(part))
+                chunk_methods.append(str(part_meta.get("decode_method", "")))
+                chunk_alphabets.append(str(part_meta.get("alphabet_source", "")))
+
+                attempts = part_meta.get("decode_attempts", [])
+                if isinstance(attempts, list):
+                    for entry in attempts:
+                        attempt_entry = dict(entry)
+                        attempt_entry["chunk_index"] = index
+                        chunk_attempts.append(attempt_entry)
+
+                sanitised = {
+                    key: value
+                    for key, value in part_meta.items()
+                    if key not in {"decode_attempts"}
+                }
+                sanitised["chunk_index"] = index
+                chunk_meta_details.append(sanitised)
+
+            raw = b"".join(decoded_parts)
+
+            method_set = {method for method in chunk_methods if method}
+            if method_set:
+                if len(method_set) == 1:
+                    decode_method = next(iter(method_set))
+                else:
+                    decode_method = "mixed"
+            else:
+                decode_method = "unknown"
+
+            alphabet_set = {source for source in chunk_alphabets if source}
+            if alphabet_set:
+                if len(alphabet_set) == 1:
+                    alphabet_source = next(iter(alphabet_set))
+                else:
+                    alphabet_source = "mixed"
+            else:
+                alphabet_source = "n/a"
+
+            decode_meta: Dict[str, object] = {
+                "decode_method": decode_method,
+                "alphabet_source": alphabet_source,
+                "chunk_count": len(chunk_texts),
+                "chunk_lengths": chunk_encoded_lengths,
+                "chunk_decoded_bytes": chunk_decoded_bytes,
+                "chunk_methods": chunk_methods,
+                "chunk_alphabet_sources": chunk_alphabets,
+                "chunk_meta": chunk_meta_details,
+                "index_xor": any(
+                    bool(meta.get("index_xor")) for meta in chunk_meta_details
+                ),
+                "script_key_length": len(script_key),
+            }
+            if chunk_attempts:
+                decode_meta["decode_attempts"] = chunk_attempts
+
+            aggregated_errors: List[Dict[str, object]] = []
+            for meta in chunk_meta_details:
+                errors = meta.get("decode_errors")
+                if errors:
+                    aggregated_errors.append(
+                        {
+                            "chunk_index": meta.get("chunk_index"),
+                            "errors": errors,
+                        }
+                    )
+            if aggregated_errors:
+                decode_meta["decode_errors"] = aggregated_errors
+
+            for flag in ("low_confidence", "fallback_used", "base91_forced"):
+                if any(meta.get(flag) for meta in chunk_meta_details):
+                    decode_meta[flag] = True
+
+        else:
+            raw, decode_meta = decode_blob_with_metadata(
+                payload.text,
+                script_key,
+                alphabet=alphabet,
+            )
         metadata["decoded_bytes"] = len(raw)
         metadata.update({key: value for key, value in decode_meta.items() if key != "decode_attempts"})
         if decode_meta.get("decode_attempts"):

--- a/tests/test_luraph_v1441.py
+++ b/tests/test_luraph_v1441.py
@@ -1,4 +1,5 @@
 import base64
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -45,6 +46,41 @@ def _make_sample(raw: bytes | None = None, *, script_key: str = "SuperSecretKey"
         "return init_fn(payload)\n"
     )
     return script, payload, script_key, blob
+
+
+def _make_chunked_sample(
+    raw: bytes | None = None,
+    *,
+    script_key: str = "SuperSecretKey",
+    chunk_count: int = 3,
+) -> tuple[str, bytes, str, list[str]]:
+    payload = raw if raw is not None else bytes(range(256)) * 2
+    key_bytes = script_key.encode("utf-8")
+    chunk_count = max(1, chunk_count)
+    chunk_size = max(1, (len(payload) + chunk_count - 1) // chunk_count)
+    chunks = [payload[index : index + chunk_size] for index in range(0, len(payload), chunk_size)]
+    encoded_chunks: list[str] = []
+    for chunk in chunks:
+        masked = _apply_script_key_transform(chunk, key_bytes)
+        encoded_chunks.append(_encode_base91(masked))
+
+    chunk_lines = [f"local chunk_{index} = \"{chunk}\"" for index, chunk in enumerate(encoded_chunks)]
+    concat_expr = " .. ".join(f"chunk_{index}" for index in range(len(encoded_chunks)))
+
+    script = "\n".join(
+        [
+            "-- Luraph v14.4.1 chunked bootstrap",
+            f"local script_key = script_key or \"{script_key}\"",
+            "local init_fn = function(blob)",
+            "    return blob",
+            "end",
+            *chunk_lines,
+            f"local payload = {concat_expr}",
+            "return init_fn(payload)",
+        ]
+    )
+
+    return script, payload, script_key, encoded_chunks
 
 
 def _write_bootstrap_stub(tmp_path: Path) -> Path:
@@ -162,7 +198,7 @@ def test_initv4_decoder_extracts_metadata(tmp_path: Path) -> None:
     assert decoder.alphabet is not None and len(decoder.alphabet) >= 85
 
     payloads = decoder.locate_payload(script)
-    assert blob in payloads
+    assert f'"{blob}"' in payloads
 
     decoded = decoder.extract_bytecode(payloads[0])
     assert decoded == raw
@@ -172,6 +208,34 @@ def test_initv4_decoder_extracts_metadata(tmp_path: Path) -> None:
     assert opcode_table.get(0x2A) == "FORLOOP"
     assert opcode_table.get(0x2B) == "TFORLOOP"
     assert opcode_table.get(0x22) == "CONCAT"
+
+
+def test_v1441_handler_decodes_chunked_payload() -> None:
+    script, raw, script_key, encoded_chunks = _make_chunked_sample(chunk_count=4)
+    handler = LuraphV1441()
+
+    payload = handler.locate_payload(script)
+    assert payload is not None
+
+    meta_before = dict(payload.metadata)
+    assert meta_before.get("chunk_count") == len(encoded_chunks)
+    assert isinstance(meta_before.get("chunks"), list)
+
+    decoded = handler.extract_bytecode(payload)
+    assert decoded == raw
+
+    meta_after = payload.metadata
+    assert meta_after.get("chunk_count") == len(encoded_chunks)
+    assert "_chunks" not in meta_after
+
+    chunk_size = max(1, (len(raw) + len(encoded_chunks) - 1) // len(encoded_chunks))
+    expected_decoded = [len(raw[index : index + chunk_size]) for index in range(0, len(raw), chunk_size)]
+    assert meta_after.get("chunk_decoded_bytes") == expected_decoded
+    assert meta_after.get("chunk_lengths") == [len(chunk) for chunk in encoded_chunks]
+
+    attempts = meta_after.get("decode_attempts", [])
+    assert attempts
+    assert {entry.get("chunk_index") for entry in attempts} == set(range(len(encoded_chunks)))
 
 
 def test_extract_bytecode_includes_bootstrap_info(tmp_path: Path) -> None:
@@ -219,6 +283,7 @@ def test_payload_decode_uses_script_key(tmp_path: Path) -> None:
         stage_output=script,
         script_key=script_key,
     )
+    ctx.detected_version = VersionDetector().info_for_name("luraph_v14_4_initv4")
 
     metadata = payload_decode_run(ctx)
 
@@ -267,6 +332,45 @@ return 'ok'"""
     assert payload_meta.get("index_xor") is True
     assert payload_meta.get("alphabet_source") == "default"
     assert ctx.report.script_key_used == EXAMPLE_SCRIPT_KEY
+
+
+def test_payload_decode_handles_chunked_script(tmp_path: Path) -> None:
+    script_body = "\n".join(["print('chunked payload!')"] * 8)
+    raw_mapping = {"bytecode": [], "constants": [], "script": script_body}
+    raw_bytes = json.dumps(raw_mapping).encode("utf-8")
+    chunk_count = 4
+    script, _, script_key, encoded_chunks = _make_chunked_sample(
+        raw=raw_bytes,
+        script_key=EXAMPLE_SCRIPT_KEY,
+        chunk_count=chunk_count,
+    )
+
+    path = tmp_path / "chunked.lua"
+    path.write_text(script, encoding="utf-8")
+
+    ctx = Context(
+        input_path=path,
+        raw_input=script,
+        stage_output=script,
+        script_key=script_key,
+    )
+
+    metadata = payload_decode_run(ctx)
+
+    assert ctx.stage_output.strip() == script_body.strip()
+    payload_meta = metadata.get("handler_payload_meta", {})
+    assert payload_meta.get("chunk_count") == chunk_count
+    assert payload_meta.get("chunk_lengths") == [len(chunk) for chunk in encoded_chunks]
+
+    chunk_size = max(1, (len(raw_bytes) + chunk_count - 1) // chunk_count)
+    expected_decoded = [len(raw_bytes[index : index + chunk_size]) for index in range(0, len(raw_bytes), chunk_size)]
+    assert payload_meta.get("chunk_decoded_bytes") == expected_decoded
+
+    assert metadata.get("handler_payload_chunks") == chunk_count
+    assert ctx.report.blob_count == chunk_count
+    assert ctx.report.decoded_bytes >= len(raw_bytes)
+    assert ctx.report.script_key_used == script_key
+    assert ctx.decoded_payloads and ctx.decoded_payloads[-1].strip() == script_body.strip()
 
 
 def test_payload_decode_with_wrong_key_returns_bootstrap(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- update the initv4 helper to return all quoted payload blobs and teach the v14.4.1 handler to locate multiple chunked strings
- decode each chunk sequentially, aggregate metadata for reporting, and plumb chunk counts through the deobfuscator and payload pass
- extend the v14.4.1 test suite with chunked fixtures and pipeline coverage

## Testing
- pytest tests/test_luraph_v1441.py

------
https://chatgpt.com/codex/tasks/task_e_68d09dc6aeb4832cb9d0b1c0ee079b0d