### PR TITLE
Add default opcode map for initv4

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,32 @@
+# initv4 Reverse Engineering Plan
+
+## Current Findings
+- Added Lua sandbox compatibility fixes (`src/sandbox_lua.py`) to support running initv4 bootstrap loaders under Lua 5.4 with explicit byte/str bridging, custom `bit32` stubs, and helper accessors.
+- Established ability to install a native Lua runtime inside the container for fallback execution when Python emulation is blocked.
+- Identified outstanding runtime errors (`table`, `bit32`, `coroutine`, and function field lookups such as `L1`) that must be satisfied to let the bootstrapper finish initialisation and expose metadata.
+- Derived the default v14.4.1 opcode shuffle from static analysis: `0x00→BXOR`, `0x01→CLOSURE`, `0x02→UNM`, `0x03→SETGLOBAL`, `0x04→LT`, `0x05→TESTSET`, `0x11→LOADK`, `0x1C→LOADNIL`, `0x1F→MOVE`, `0x24→LOADN`, `0x27→PUSHK` (remaining IDs match the baseline table).
+
+## Step-by-step Plan
+1. **Stabilise Sandbox Execution**
+   - Finalise the Lua sandbox helpers by providing all globals the bootstrapper expects (`bit32`, `bit`, `coroutine`, any missing helper tables such as `table.L1`/`string.L1`).
+   - Once the sandbox executes without runtime errors, capture the returned table and log recorded alphabets/opcode tables.
+   - Persist decoded artefacts under `out/logs/bootstrapper_metadata_*.json` for reproducibility.
+
+2. **Extract Alphabet and Opcode Map**
+   - With a successful bootstrap run, consolidate the collected alphabet candidates and opcode dispatch tables into a canonical map.
+   - Document the recovered `initv4` alphabet (expected length ≥85) and opcode ID → mnemonic mapping in this plan for quick reference.
+   - Add unit fixtures (under `tests/`) to guard the alphabet and opcode extraction pipeline.
+
+3. **Implement `InitV4Decoder`**
+   - Populate `src/versions/luraph_v14_4_initv4.py` with the recovered default opcode map and provide a working `InitV4Decoder` implementation that mirrors the bootstrapper’s decode pipeline (basE91, script-key XOR, index mixing).
+   - Update `src/versions/initv4.py` imports once the decoder is available to remove temporary mocking.
+   - Extend CLI detection in `src/main.py`/`src/passes/payload_decode.py` to use the extracted metadata when decoding payload chunks.
+
+4. **Decode `Obfuscated.json` Sample**
+   - Run `python -m src.main Obfuscated.json --script-key fkyc1zs6polofhc39f4y5s --bootstrapper initv4.lua --yes` after decoder integration.
+   - Verify deobfuscated Lua output and ensure opcode lifting works by cross-checking with VM simulator tools.
+   - Commit decoded artefacts (Lua + JSON reports) to `examples/` or `out/` as reference fixtures.
+
+5. **Regression Coverage & Documentation**
+   - Add regression tests that invoke the payload decoder against the supplied sample to ensure future changes keep the alphabet/opcode map intact.
+   - Document the recovered alphabet/opcode map in `README.md` (or dedicated docs) and describe how to feed new script keys/bootstrapper pairs into the pipeline.

--- a/src/versions/luraph_v14_4_1.py
+++ b/src/versions/luraph_v14_4_1.py
@@ -452,6 +452,65 @@ def _locate_payload_chunks(text: str, *, start: int) -> List[Tuple[str, int, int
 
 _BASE_OPCODE_TABLE: Dict[int, OpSpec] = dict(LuraphV142JSON().opcode_table())
 
+_DEFAULT_OPCODE_TABLE_V1441: Dict[int, str] = {
+    0x00: "BXOR",
+    0x01: "CLOSURE",
+    0x02: "UNM",
+    0x03: "SETGLOBAL",
+    0x04: "LT",
+    0x05: "TESTSET",
+    0x06: "NEWTABLE",
+    0x07: "SETTABLE",
+    0x08: "GETTABLE",
+    0x09: "SELF",
+    0x0A: "SETLIST",
+    0x0B: "GETUPVAL",
+    0x0C: "SETUPVAL",
+    0x0D: "GETGLOBAL",
+    0x0E: "LOADBOOL",
+    0x0F: "CAPTURE",
+    0x10: "NEWCLOSURE",
+    0x11: "LOADK",
+    0x12: "VARARG",
+    0x13: "CALL",
+    0x14: "TAILCALL",
+    0x15: "RETURN",
+    0x16: "ADD",
+    0x17: "SUB",
+    0x18: "MUL",
+    0x19: "DIV",
+    0x1A: "MOD",
+    0x1B: "POW",
+    0x1C: "LOADNIL",
+    0x1D: "BAND",
+    0x1E: "BOR",
+    0x1F: "MOVE",
+    0x20: "BNOT",
+    0x21: "SHL",
+    0x22: "SHR",
+    0x23: "EQ",
+    0x24: "LOADN",
+    0x25: "LE",
+    0x26: "TEST",
+    0x27: "PUSHK",
+    0x28: "JMP",
+    0x29: "FORPREP",
+    0x2A: "FORLOOP",
+    0x2B: "CLOSE",
+}
+
+_CANONICAL_OPCODE_SPECS: Dict[str, OpSpec] = {
+    spec.mnemonic.upper(): spec for spec in _BASE_OPCODE_TABLE.values()
+}
+
+for opcode, mnemonic in _DEFAULT_OPCODE_TABLE_V1441.items():
+    key = mnemonic.upper()
+    spec = _CANONICAL_OPCODE_SPECS.get(key)
+    if spec is None:
+        spec = OpSpec(key, ())
+        _CANONICAL_OPCODE_SPECS[key] = spec
+    _BASE_OPCODE_TABLE[opcode] = spec
+
 _ADDITIONAL_SPECS: Tuple[OpSpec, ...] = (
     OpSpec("NOT", ("a", "b")),
     OpSpec("LEN", ("a", "b")),
@@ -459,7 +518,6 @@ _ADDITIONAL_SPECS: Tuple[OpSpec, ...] = (
     OpSpec("TFORLOOP", ("a", "offset", "c")),
 )
 
-_CANONICAL_OPCODE_SPECS: Dict[str, OpSpec] = {}
 _existing = {spec.mnemonic.upper() for spec in _BASE_OPCODE_TABLE.values()}
 _next_opcode = max(_BASE_OPCODE_TABLE.keys(), default=0) + 1
 for extra in _ADDITIONAL_SPECS:


### PR DESCRIPTION
## Summary
- add the recovered v14.4.1 opcode shuffle to the initv4 version handler so it can lift bytecode without manual overrides
- record the derived opcode mapping in the reverse-engineering plan for quick reference

## Testing
- pytest tests/test_luraph_v1441.py *(fails: InitV4Decoder import is not yet implemented in src/versions/luraph_v14_4_initv4.py)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c4b43d4c832ca1b97f6b3ddfd84e