### PR TITLE
Implement Lua PRGA reference and fallback support

### DIFF
--- a/lua/initv4_prga_ref.lua
+++ b/lua/initv4_prga_ref.lua
@@ -1,28 +1,60 @@
-# Pseudo-Lua module compatible with the fallback lupa shim.
-from __future__ import annotations
+local function xor_byte(a, b)
+    local result = 0
+    local bit_value = 1
 
-from typing import ByteString
+    while a > 0 or b > 0 do
+        local abit = a % 2
+        local bbit = b % 2
+        if abit ~= bbit then
+            result = result + bit_value
+        end
+        a = math.floor((a - abit) / 2)
+        b = math.floor((b - bbit) / 2)
+        bit_value = bit_value * 2
+    end
 
+    return result
+end
 
-def apply_prga_ref(decoded_lph: ByteString, key: ByteString) -> bytes:
-    if not key:
-        raise ValueError("key must be non-empty")
+local function rotate_right8(value, rotation)
+    rotation = rotation % 8
+    if rotation == 0 then
+        return value % 256
+    end
 
-    decoded = memoryview(decoded_lph)
-    key_bytes = memoryview(key)
-    key_len = len(key_bytes)
+    value = value % 256
+    local shifted = math.floor(value / (2 ^ rotation))
+    local wrapped = (value * (2 ^ (8 - rotation))) % 256
+    return (shifted + wrapped) % 256
+end
 
-    output = bytearray(len(decoded))
-    for index, value in enumerate(decoded):
-        key_byte = key_bytes[index % key_len]
-        mixed = value ^ key_byte
-        rotation = key_byte & 7
-        if rotation:
-            mixed &= 0xFF
-            mixed = ((mixed >> rotation) | ((mixed << (8 - rotation)) & 0xFF)) & 0xFF
-        output[index] = mixed
-    return bytes(output)
+local function apply_prga_ref(decoded_lph, key)
+    if type(key) ~= "string" or #key == 0 then
+        error("key must be a non-empty string")
+    end
+    if type(decoded_lph) ~= "string" then
+        error("decoded_lph must be a string")
+    end
 
+    local key_len = #key
+    local output = {}
 
-initv4_prga_ref = {}
-initv4_prga_ref["apply_prga_ref"] = apply_prga_ref
+    for index = 1, #decoded_lph do
+        local value = decoded_lph:byte(index)
+        local key_byte = key:byte(((index - 1) % key_len) + 1)
+        local mixed = xor_byte(value, key_byte)
+        local rotation = key_byte % 8
+        mixed = rotate_right8(mixed, rotation)
+        output[index] = string.char(mixed)
+    end
+
+    return table.concat(output)
+end
+
+local module = {
+    apply_prga_ref = apply_prga_ref,
+}
+
+initv4_prga_ref = module
+
+return module


### PR DESCRIPTION
## Summary
- replace the pseudo-Lua PRGA reference with a real Lua implementation of the XOR-plus-rotate algorithm
- teach the fallback LuaRuntime shim to recognise the Lua module and expose apply_prga_ref so tests keep working

## Testing
- pytest tests/test_initv4_prga_parity.py

------
https://chatgpt.com/codex/tasks/task_e_69002cfd088c832ca7ef164b9a6657b3