### PR TITLE
Add strict flag and positional path support to ensure_no_keys CLI

### DIFF
--- a/tests/test_tools_ensure_no_keys.py
+++ b/tests/test_tools_ensure_no_keys.py
@@ -52,3 +52,31 @@ def test_cli_returns_error_code(
     assert exit_code == 1
     messages = "\n".join(record.getMessage() for record in caplog.records)
     assert "profile.json" in messages
+
+
+def test_cli_supports_positional_directory_with_strict(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    out_dir = tmp_path / "out"
+    _write_json(out_dir / "report.json", {"token": "value"})
+
+    caplog.set_level(logging.ERROR)
+    exit_code = ensure_no_keys_main(["--strict", str(out_dir)])
+
+    assert exit_code == 1
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert "report.json" in messages
+
+
+def test_cli_no_strict_allows_warnings(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    out_dir = tmp_path / "out"
+    _write_json(out_dir / "report.json", {"token": "value"})
+
+    caplog.set_level(logging.WARNING)
+    exit_code = ensure_no_keys_main(["--no-strict", str(out_dir)])
+
+    assert exit_code == 0
+    warnings = "\n".join(record.getMessage() for record in caplog.records)
+    assert "report.json" in warnings


### PR DESCRIPTION
## Summary
- add positional directory support to the ensure_no_keys CLI while keeping the existing option flag
- introduce a --strict/--no-strict toggle so automation can require or relax fatal violations
- extend the ensure_no_keys tests to cover the new CLI usages

## Testing
- pytest tests/test_tools_ensure_no_keys.py
- python -m src.tools.ensure_no_keys --strict out

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916970330ac832ca931f78c4b9e02c1)