### PR TITLE
Annotate F3 slot usage across runtime contexts

### DIFF
--- a/tests/test_runtime_ir_annotations.py
+++ b/tests/test_runtime_ir_annotations.py
@@ -2,7 +2,8 @@ from dataclasses import dataclass, field
 from types import SimpleNamespace
 
 from opcode_lifter import BootstrapIR
-from pattern_analyzer import CacheSlot
+from pattern_analyzer import CacheSlot, SerializedChunk
+from string_decryptor import StringDecoderDescriptor
 
 from src.passes.runtime_ir_annotations import RuntimeIRAnnotationPass
 
@@ -62,3 +63,84 @@ def test_runtime_ir_annotation_pass_handles_missing_attributes() -> None:
     assert summary.control_state_machine is None
     assert "runtime" in getattr(bootstrap, "annotations")
     assert "constant_cache" in bootstrap.annotations["runtime"]
+
+
+def test_runtime_ir_annotation_pass_tracks_f3_usage_contexts() -> None:
+    bootstrap = BootstrapIR(
+        cache_slots=[
+            CacheSlot(
+                index_literal="0x1",
+                index_value=1,
+                expressions=["F3[1] = 1"],
+                classification="constant",
+                semantic_role="string token",
+            ),
+            CacheSlot(
+                index_literal="0x2",
+                index_value=2,
+                expressions=["F3[2] = 2"],
+                classification="constant",
+                semantic_role="serialized blob offset",
+            ),
+            CacheSlot(
+                index_literal="0x3",
+                index_value=3,
+                expressions=["F3[3] = 3"],
+                classification="constant",
+                semantic_role="vm arithmetic seed",
+            ),
+            CacheSlot(
+                index_literal="0x4",
+                index_value=4,
+                expressions=["F3[4] = 4"],
+                classification="constant",
+                semantic_role="guard value",
+            ),
+        ],
+        string_decoder=StringDecoderDescriptor(
+            closure_variable="t",
+            invocation="return F3[1]",
+            gsub_alias="g",
+            metatable_alias="mt",
+            cache_table="F3",
+            token_variable="token",
+            token_length=16,
+            local_variable_count=3,
+            caches_results=True,
+        ),
+        serialized_chunk=SerializedChunk(
+            buffer_name="payload",
+            initial_offset=0,
+            helper_functions={"reader": "return F3[2]"},
+        ),
+    )
+
+    vm_entry = MockVMEntry(
+        control_variable="state",
+        captures={
+            "dispatcher": "acc = acc + F3[3]",
+            "fallback_path": "-- rare handler\nreturn F3[4]",
+        },
+    )
+
+    annotator = RuntimeIRAnnotationPass()
+    summary = annotator.run(bootstrap, vm_entry)
+
+    usage = summary.slot_usage
+    assert usage[1]["used_in_string_decoder"] is True
+    assert usage[1]["used_in_serialized_data"] is False
+    assert usage[1]["used_in_vm_core"] is False
+    assert usage[1]["rarely_referenced"] is False
+
+    assert usage[2]["used_in_serialized_data"] is True
+    assert usage[2]["used_in_vm_core"] is False
+
+    assert usage[3]["used_in_vm_core"] is True
+    assert usage[3]["rarely_referenced"] is False
+
+    assert usage[4]["rarely_referenced"] is True
+    assert usage[4]["used_in_vm_core"] is False
+
+    constant_cache_annotations = bootstrap.annotations["runtime"]["constant_cache"]
+    assert str(1) in constant_cache_annotations["slot_usage"]
+    assert constant_cache_annotations["rare_slots"] == [4]


### PR DESCRIPTION
## Summary
- add per-slot usage flags to the runtime annotations and surface context-aware summaries of F3 references
- implement a runtime annotation pass that classifies cache usage across string decoding, serialized data, VM core logic, and rare branches
- extend runtime annotation tests to cover the new classification heuristics

## Testing
- pytest tests/test_runtime_ir_annotations.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691786ca5200832c8ffe64ce39df11ed)